### PR TITLE
Include additional permissions required for Prowler Scan

### DIFF
--- a/1-sat2-member-roles.yaml
+++ b/1-sat2-member-roles.yaml
@@ -55,11 +55,11 @@ Resources:
                 - codeartifact:List*
                 - codebuild:BatchGet*
                 - cognito-idp:GetUserPoolMfaConfig
+                - dlm:Get*
                 - drs:Describe*
                 - ds:Get*
                 - ds:Describe*
                 - ds:List*
-                - dlm:GetLifecyclePolicies
                 - dynamodb:GetResourcePolicy
                 - ec2:GetEbsEncryptionByDefault
                 - ec2:GetInstanceMetadataDefaults

--- a/1-sat2-member-roles.yaml
+++ b/1-sat2-member-roles.yaml
@@ -54,11 +54,15 @@ Resources:
                 - cloudtrail:GetInsightSelectors
                 - codeartifact:List*
                 - codebuild:BatchGet*
+                - cognito-idp:GetUserPoolMfaConfig
                 - drs:Describe*
                 - ds:Get*
                 - ds:Describe*
                 - ds:List*
+                - dlm:GetLifecyclePolicies
+                - dynamodb:GetResourcePolicy
                 - ec2:GetEbsEncryptionByDefault
+                - ec2:GetInstanceMetadataDefaults
                 - ecr:Describe*
                 - ecr:GetRegistryScanningConfiguration
                 - elasticfilesystem:DescribeBackupPolicy
@@ -66,6 +70,7 @@ Resources:
                 - glue:GetSecurityConfiguration*
                 - glue:SearchTables
                 - lambda:GetFunction*
+                - lightsail:GetRelationalDatabases
                 - logs:FilterLogEvents
                 - macie2:GetMacieSession
                 - s3:GetAccountPublicAccessBlock

--- a/2-sat2-codebuild-prowler.yaml
+++ b/2-sat2-codebuild-prowler.yaml
@@ -122,11 +122,15 @@ Resources:
                 - cloudtrail:GetInsightSelectors
                 - codeartifact:List*
                 - codebuild:BatchGet*
+                - cognito-idp:GetUserPoolMfaConfig
+                - dlm:Get*
                 - drs:Describe*
                 - ds:Get*
                 - ds:Describe*
                 - ds:List*
+                - dynamodb:GetResourcePolicy
                 - ec2:GetEbsEncryptionByDefault
+                - ec2:GetInstanceMetadataDefaults
                 - ecr:Describe*
                 - ecr:GetRegistryScanningConfiguration
                 - elasticfilesystem:DescribeBackupPolicy
@@ -134,6 +138,7 @@ Resources:
                 - glue:GetSecurityConfiguration*
                 - glue:SearchTables
                 - lambda:GetFunction*
+                - lightsail:GetRelationalDatabases
                 - logs:FilterLogEvents
                 - macie2:GetMacieSession
                 - s3:GetAccountPublicAccessBlock


### PR DESCRIPTION
Include additional permissions that Prowler needs to scan various series effectively

*Issue #, if available:*
Multiple Errors Are reported in the Prowler scan logs.  A few are included here
```
- [Module: dlm_service]	 ERROR:  <region> ClientError[23]: An error occurred (AccessDeniedException) when calling the GetLifecyclePolicies operation: User: arn:aws:sts::XXXXXXXXXXXX:assumed-role/ProwlerMemberRole/ProwlerAssessmentSession is not authorized to perform: dlm:GetLifecyclePolicies on resource: arn:aws:dlm:<region>:XXXXXXXXXXXX:policy/*
- [Module: ec2_service]	 ERROR: <region> -- ClientError[402]: An error occurred (UnauthorizedOperation) when calling the GetSnapshotBlockPublicAccessState operation: You are not authorized to perform this operation. User: arn:aws:sts::<region>:assumed-role/ProwlerMemberRole/ProwlerAssessmentSession is not authorized to perform: ec2:GetSnapshotBlockPublicAccessState because no identity-based policy allows the ec2:GetSnapshotBlockPublicAccessState action
- [Module: dynamodb_service]	 ERROR: <region> -- type[104]: An error occurred (AccessDeniedException) when calling the GetResourcePolicy operation: User: arn:aws:sts::XXXXXXXXXXXX:assumed-role/ProwlerMemberRole/ProwlerAssessmentSession is not authorized to perform: dynamodb:GetResourcePolicy on resource: arn:aws:dynamodb:<region>:XXXXXXXXXXXX:table/multiregion-ddb because no identity-based policy allows the dynamodb:GetResourcePolicy action
```
- 

*Description of changes:*
This PR includes the additional permissions that Prowler needs to scan the various AWS services. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
