### PR TITLE
chore(permissions): missing ec2 snapshot permission

### DIFF
--- a/2-sat2-codebuild-prowler.yaml
+++ b/2-sat2-codebuild-prowler.yaml
@@ -131,6 +131,7 @@ Resources:
                 - dynamodb:GetResourcePolicy
                 - ec2:GetEbsEncryptionByDefault
                 - ec2:GetInstanceMetadataDefaults
+                - ec2:GetSnapshotBlockPublicAccessState
                 - ecr:Describe*
                 - ecr:GetRegistryScanningConfiguration
                 - elasticfilesystem:DescribeBackupPolicy


### PR DESCRIPTION
*Description of changes:*

Missing permission `ec2:GetSnapshotBlockPublicAccessState` for Prowler check `ec2_ebs_snapshot_account_block_public_access`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
