### PR TITLE
Add "FortyEight" option for very high parallelism

### DIFF
--- a/2-sat2-codebuild-prowler.yaml
+++ b/2-sat2-codebuild-prowler.yaml
@@ -86,7 +86,7 @@ Parameters:
       - 'Three'
       - 'Six'
       - 'Twelve'
-      - 'FourtyEight'
+      - 'FortyEight'
     Default: 'Three'
   CodeBuildTimeout:
     Description: 'Set the timeout for the CodeBuild job. The default is 300 minutes (5 hours).'
@@ -138,7 +138,7 @@ Mappings:
     Twelve:
       ParallelAccounts: 12
       CodeBuildComputeType: BUILD_GENERAL1_LARGE
-    FourtyEight:
+    FortyEight:
       ParallelAccounts: 48
       CodeBuildComputeType: BUILD_GENERAL1_XLARGE
 

--- a/2-sat2-codebuild-prowler.yaml
+++ b/2-sat2-codebuild-prowler.yaml
@@ -86,7 +86,6 @@ Parameters:
       - 'Three'
       - 'Six'
       - 'Twelve'
-      - 'TwentyFour'
       - 'FourtyEight'
     Default: 'Three'
   CodeBuildTimeout:
@@ -139,12 +138,10 @@ Mappings:
     Twelve:
       ParallelAccounts: 12
       CodeBuildComputeType: BUILD_GENERAL1_LARGE
-    TwentyFour:
-      ParallelAccounts: 24
-      CodeBuildComputeType: BUILD_GENERAL1_XLARGE
     FourtyEight:
       ParallelAccounts: 48
-      CodeBuildComputeType: BUILD_GENERAL1_2XLARGE
+      CodeBuildComputeType: BUILD_GENERAL1_XLARGE
+
 Resources:
   #This is the role that CodeBuild assumes to perform the Prowler scan
   ProwlerIntegrationCodeBuildRole:

--- a/2-sat2-codebuild-prowler.yaml
+++ b/2-sat2-codebuild-prowler.yaml
@@ -87,6 +87,7 @@ Parameters:
       - 'Six'
       - 'Twelve'
       - 'TwentyFour'
+      - 'FourtyEight'
     Default: 'Three'
   CodeBuildTimeout:
     Description: 'Set the timeout for the CodeBuild job. The default is 300 minutes (5 hours).'
@@ -141,6 +142,9 @@ Mappings:
     TwentyFour:
       ParallelAccounts: 24
       CodeBuildComputeType: BUILD_GENERAL1_XLARGE
+    FourtyEight:
+      ParallelAccounts: 48
+      CodeBuildComputeType: BUILD_GENERAL1_2XLARGE
 Resources:
   #This is the role that CodeBuild assumes to perform the Prowler scan
   ProwlerIntegrationCodeBuildRole:

--- a/2-sat2-codebuild-prowler.yaml
+++ b/2-sat2-codebuild-prowler.yaml
@@ -86,6 +86,7 @@ Parameters:
       - 'Three'
       - 'Six'
       - 'Twelve'
+      - 'TwentyFour'
     Default: 'Three'
   CodeBuildTimeout:
     Description: 'Set the timeout for the CodeBuild job. The default is 300 minutes (5 hours).'
@@ -137,7 +138,9 @@ Mappings:
     Twelve:
       ParallelAccounts: 12
       CodeBuildComputeType: BUILD_GENERAL1_LARGE
-
+    TwentyFour:
+      ParallelAccounts: 24
+      CodeBuildComputeType: BUILD_GENERAL1_XLARGE
 Resources:
   #This is the role that CodeBuild assumes to perform the Prowler scan
   ProwlerIntegrationCodeBuildRole:


### PR DESCRIPTION
For customers with a huge number of accounts, this should save a considerable amount of time

*Issue #, if available:* #18

*Description of changes:*

Add an option to run twenty four scans at once.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
