### PR TITLE
Remove superfluous BucketEncryption property. Resolves #23

### DIFF
--- a/2-sat2-codebuild-prowler.yaml
+++ b/2-sat2-codebuild-prowler.yaml
@@ -242,10 +242,6 @@ Resources:
       NotificationConfiguration:
            EventBridgeConfiguration:
                 EventBridgeEnabled: !If [ EnableReporting, true, false ]
-      BucketEncryption: 
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
       VersioningConfiguration:
         Status: Enabled
       PublicAccessBlockConfiguration:

--- a/2-sat2-codebuild-prowler.yaml
+++ b/2-sat2-codebuild-prowler.yaml
@@ -235,6 +235,8 @@ Resources:
         rules_to_suppress:
           - id: W35
             reason: No bucket logging needed.
+          - id: W41
+            reason: "Amazon S3 now applies server-side encryption with Amazon S3 managed keys (SSE-S3) as the base level of encryption for every bucket in Amazon S3."
     UpdateReplacePolicy: Retain
     DeletionPolicy: Retain 
     Type: AWS::S3::Bucket

--- a/2-sat2-codebuild-prowler.yaml
+++ b/2-sat2-codebuild-prowler.yaml
@@ -236,7 +236,7 @@ Resources:
           - id: W35
             reason: No bucket logging needed.
           - id: W41
-            reason: "Amazon S3 now applies server-side encryption with Amazon S3 managed keys (SSE-S3) as the base level of encryption for every bucket in Amazon S3."
+            reason: Amazon S3 now applies server-side encryption with Amazon S3 managed keys (SSE-S3) as the base level of encryption for every bucket in Amazon S3.
     UpdateReplacePolicy: Retain
     DeletionPolicy: Retain 
     Type: AWS::S3::Bucket


### PR DESCRIPTION
*Issue #, if available:* 23

*Description of changes:*. Removing explicit `BucketEncryption` property as it is 1) unneeded and 2) prevents deploying the solution in OUs with the AWS-GR_AUDIT_BUCKET_ENCRYPTION_ENABLED Control Tower control enabled (i.e. the Security OU).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
