### PR TITLE
Aligning ProwlerMemberRole inline policy with latest prowler version check access requirements

### DIFF
--- a/1-sat2-member-roles.yaml
+++ b/1-sat2-member-roles.yaml
@@ -87,6 +87,7 @@ Resources:
                 - securityhub:GetFindings
                 - servicecatalog:Describe*
                 - servicecatalog:List*
+                - ssm:DescribeDocumentPermission
                 - ssm:GetDocument
                 - ssm-incidents:List*
                 - states:ListTagsForResource

--- a/1-sat2-member-roles.yaml
+++ b/1-sat2-member-roles.yaml
@@ -51,9 +51,13 @@ Resources:
                 - appstream:Describe*
                 - appstream:List*
                 - backup:List*
+                - backup:Get*
+                - bedrock:List*
+                - bedrock:Get*
                 - cloudtrail:GetInsightSelectors
                 - codeartifact:List*
                 - codebuild:BatchGet*
+                - codebuild:ListReportGroups
                 - cognito-idp:GetUserPoolMfaConfig
                 - dlm:Get*
                 - drs:Describe*
@@ -70,17 +74,22 @@ Resources:
                 - glue:GetConnections
                 - glue:GetSecurityConfiguration*
                 - glue:SearchTables
+                - glue:GetMLTransforms
                 - lambda:GetFunction*
                 - lightsail:GetRelationalDatabases
                 - logs:FilterLogEvents
                 - macie2:GetMacieSession
+                - macie2:GetAutomatedDiscoveryConfiguration
                 - s3:GetAccountPublicAccessBlock
                 - shield:DescribeProtection
                 - shield:GetSubscriptionState
                 - securityhub:BatchImportFindings
                 - securityhub:GetFindings
+                - servicecatalog:Describe*
+                - servicecatalog:List*
                 - ssm:GetDocument
                 - ssm-incidents:List*
+                - states:ListTagsForResource
                 - support:Describe*
                 - tag:GetTagKeys
                 - wellarchitected:List*

--- a/2-sat2-codebuild-prowler.yaml
+++ b/2-sat2-codebuild-prowler.yaml
@@ -187,9 +187,13 @@ Resources:
                 - appstream:Describe*
                 - appstream:List*
                 - backup:List*
+                - backup:Get*
+                - bedrock:List*
+                - bedrock:Get*
                 - cloudtrail:GetInsightSelectors
                 - codeartifact:List*
                 - codebuild:BatchGet*
+                - codebuild:ListReportGroups
                 - cognito-idp:GetUserPoolMfaConfig
                 - dlm:Get*
                 - drs:Describe*
@@ -206,17 +210,23 @@ Resources:
                 - glue:GetConnections
                 - glue:GetSecurityConfiguration*
                 - glue:SearchTables
+                - glue:GetMLTransforms
                 - lambda:GetFunction*
                 - lightsail:GetRelationalDatabases
                 - logs:FilterLogEvents
                 - macie2:GetMacieSession
+                - macie2:GetAutomatedDiscoveryConfiguration
                 - s3:GetAccountPublicAccessBlock
                 - shield:DescribeProtection
                 - shield:GetSubscriptionState
                 - securityhub:BatchImportFindings
                 - securityhub:GetFindings
+                - servicecatalog:Describe*
+                - servicecatalog:List*
+                - ssm:DescribeDocumentPermission
                 - ssm:GetDocument
                 - ssm-incidents:List*
+                - states:ListTagsForResource
                 - support:Describe*
                 - tag:GetTagKeys
                 - wellarchitected:List*


### PR DESCRIPTION
*Description of changes:*
Update Prowler IAM permissions in member role template

Enhanced the IAM permissions in the 1-sat2-member-roles.yaml template to align with actions listed in upstream prowler repo https://github.com/prowler-cloud/prowler/blob/master/permissions/prowler-additions-policy.json and from prowler error output:
- Added backup:Get* permissions
- Added bedrock:List* and bedrock:Get* permissions
- Added codebuild:ListReportGroups permission
- Added glue:GetMLTransforms permission
- Added macie2:GetAutomatedDiscoveryConfiguration permission
- Added servicecatalog:Describe* and servicecatalog:List* permissions
- Added states:ListTagsForResource permission
- Added ssm:DescribeDocumentPermission permissions



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
