### PR TITLE
Remove cleartext logging of sensitive data

### DIFF
--- a/reporting/report.py
+++ b/reporting/report.py
@@ -85,7 +85,7 @@ logger.info(f"Public S3 Buckets: {s3_bucket_public_access}")
 logger.info(f"Multi-Region CloudTrail: {cloudtrail_multi_region_enabled}")
 logger.info(f"GuardDuty Enabled: {guardduty_is_enabled}")
 logger.info(f"Access Key Rotation: {iam_rotate_access_key_90_days}")
-logger.info(f"Password Policy (All findings): {iam_password_policy}")
+logger.info("Password Policy findings exist. Details are not logged for security reasons.")
 logger.info(f"Config Recorder (All Regions): {config_recorder_all_regions_enabled}")
 logger.info(f"Lambda Function (Supported Runtimes): {awslambda_function_using_supported_runtimes}")
 


### PR DESCRIPTION
Fixes #26 

*Description of changes:*
Logging of password IAM data can be a risk. Logging AWS IAM password data poses a security risk, particularly when code is run inside automated environments like CI/CD pipelines. This need not be a security risk but in general a good practice and improves security posture for the repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Please review this PR @aws-brad @js37 (apologies for tag, I found your names as top contributors for the repo)
