### PR TITLE
Add support for specifying an existing S3 bucket

### DIFF
--- a/2-sat2-codebuild-prowler.yaml
+++ b/2-sat2-codebuild-prowler.yaml
@@ -11,6 +11,7 @@ Metadata:
           - MultiAccountScan
           - Reporting
           - EmailAddress
+          - ExistingBucketName
       - Label:
           default: Advanced options
         Parameters:
@@ -39,6 +40,8 @@ Metadata:
         default: Concurrent account scans
       CodeBuildTimeout:
         default: CodeBuild timeout
+      ExistingBucketName:
+        default: (Optional) Existing S3 bucket name
 
 Parameters:
   ProwlerOptions:
@@ -95,6 +98,11 @@ Parameters:
     MaxValue: 2160
     Default: 300
 
+  ExistingBucketName:
+    Description: 'Name of an existing S3 bucket to store assessment results (leave empty to create a new bucket)'
+    Type: String
+    Default: ''
+
 Conditions:
   CreateProwlerRole: !Equals
     - !Ref MultiAccountScan
@@ -105,6 +113,9 @@ Conditions:
   EnableReporting: !Equals
     - !Ref Reporting
     - true
+
+  UseExistingBucket: !Not [!Equals [!Ref ExistingBucketName, '']]
+  CreateNewBucket: !Equals [!Ref ExistingBucketName, '']
 
 Mappings:
   ProwlerScanParameters:
@@ -240,6 +251,7 @@ Resources:
                   - !Sub arn:${AWS::Partition}:apigateway:*::/apis/*
 
   ProwlerFindingsBucket:
+    Condition: CreateNewBucket
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -262,6 +274,7 @@ Resources:
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
   ProwlerFindingsBucketPolicy:
+    Condition: CreateNewBucket
     Type: 'AWS::S3::BucketPolicy'
     Properties:
       Bucket: !Ref ProwlerFindingsBucket
@@ -413,7 +426,10 @@ Resources:
               - Action:
                   - s3:PutObject
                 Effect: Allow
-                Resource: !Sub '${ProwlerFindingsBucket.Arn}/*'
+                Resource: !If
+                  - UseExistingBucket
+                  - !Sub 'arn:${AWS::Partition}:s3:::${ExistingBucketName}/*'
+                  - !Sub '${ProwlerFindingsBucket.Arn}/*'
         - PolicyName: AssumeRole
           PolicyDocument:
             Version: '2012-10-17'
@@ -453,7 +469,7 @@ Resources:
         Type: 'LINUX_CONTAINER'
         EnvironmentVariables:
           - Name: BUCKET_REPORT
-            Value: !Ref ProwlerFindingsBucket
+            Value: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref ProwlerFindingsBucket]
             Type: PLAINTEXT
           - Name: PROWLER_OPTIONS
             Value: !Ref 'ProwlerOptions'
@@ -703,8 +719,10 @@ Resources:
     Properties:
       CatalogId: !Ref AWS::AccountId
       DatabaseInput:
-        Name: !Ref ProwlerFindingsBucket
-        Description: !Sub 'SATv2 assessment results in the ${ProwlerFindingsBucket}'
+        Name: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref ProwlerFindingsBucket]
+        Description: !Sub
+          - 'SATv2 assessment results in the ${BucketName}'
+          - BucketName: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref ProwlerFindingsBucket]
 
   GlueTableProwlerResults:
     Condition: EnableReporting
@@ -801,7 +819,9 @@ Resources:
               Type: string
             - Name: prowler_version
               Type: string
-          Location: !Sub s3://${ProwlerFindingsBucket}/csv
+          Location: !Sub
+            - s3://${BucketName}/csv
+            - BucketName: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref ProwlerFindingsBucket]
           InputFormat: org.apache.hadoop.mapred.TextInputFormat
           OutputFormat: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
           Compressed: False
@@ -836,7 +856,9 @@ Resources:
         PublishCloudWatchMetricsEnabled: false
         RequesterPaysEnabled: false
         ResultConfiguration:
-          OutputLocation: !Sub s3://${ProwlerFindingsBucket}/athena_results
+          OutputLocation: !Sub
+            - s3://${BucketName}/athena_results
+            - BucketName: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref ProwlerFindingsBucket]
         EnforceWorkGroupConfiguration: false
 
   qProwlerOrgSummary:
@@ -897,8 +919,14 @@ Resources:
                   - s3:PutObject
                   - s3:ListMultipartUploadParts
                 Resource:
-                  - !GetAtt ProwlerFindingsBucket.Arn
-                  - !Sub ${ProwlerFindingsBucket.Arn}/*
+                  - !If
+                    - UseExistingBucket
+                    - !Sub 'arn:${AWS::Partition}:s3:::${ExistingBucketName}'
+                    - !GetAtt ProwlerFindingsBucket.Arn
+                  - !If
+                    - UseExistingBucket
+                    - !Sub 'arn:${AWS::Partition}:s3:::${ExistingBucketName}/*'
+                    - !Sub '${ProwlerFindingsBucket.Arn}/*'
               - Effect: Allow
                 Action:
                   - 'glue:GetTable'
@@ -941,7 +969,7 @@ Resources:
       Environment:
         Variables:
           ATHENA_WORKGROUP: !Ref SATv2Reporting
-          BUCKET_REPORT: !Ref ProwlerFindingsBucket
+          BUCKET_REPORT: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref ProwlerFindingsBucket]
       Runtime: python3.10
       Code:
         ZipFile: |
@@ -1015,7 +1043,7 @@ Resources:
             - SUCCEEDED
             - FAILED
           workgroupName:
-            - !Ref ProwlerFindingsBucket
+            - !If [UseExistingBucket, !Ref ExistingBucketName, !Ref ProwlerFindingsBucket]
       State: ENABLED
       Targets:
         - Id: toSNS
@@ -1023,10 +1051,12 @@ Resources:
           InputTransformer:
             InputPathsMap:
               status: $.detail.currentState
-            InputTemplate: !Sub >-
-              "The query to summarize reporting has <status>."
+            InputTemplate: !Sub
+              - >-
+                "The query to summarize reporting has <status>."
 
-              "You can view your results in the ${ProwlerFindingsBucket}/reports bucket."
+                "You can view your results in the ${BucketName}/reports bucket."
+              - BucketName: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref ProwlerFindingsBucket]
 
   # PPTX reporting
   ProwlerReportingLambdaRole:
@@ -1061,8 +1091,14 @@ Resources:
                   - s3:PutObject
                   - s3:ListMultipartUploadParts
                 Resource:
-                  - !GetAtt ProwlerFindingsBucket.Arn
-                  - !Sub ${ProwlerFindingsBucket.Arn}/*
+                  - !If
+                    - UseExistingBucket
+                    - !Sub 'arn:${AWS::Partition}:s3:::${ExistingBucketName}'
+                    - !GetAtt ProwlerFindingsBucket.Arn
+                  - !If
+                    - UseExistingBucket
+                    - !Sub 'arn:${AWS::Partition}:s3:::${ExistingBucketName}/*'
+                    - !Sub '${ProwlerFindingsBucket.Arn}/*'
         - PolicyName: AccessToCodeBuild
           PolicyDocument:
             Statement:
@@ -1154,7 +1190,7 @@ Resources:
         detail:
           bucket:
             name:
-              - !Ref ProwlerFindingsBucket
+              - !If [UseExistingBucket, !Ref ExistingBucketName, !Ref ProwlerFindingsBucket]
           object:
             key:
               - wildcard: reports/*.csv
@@ -1203,8 +1239,14 @@ Resources:
                   - s3:PutObject
                   - s3:ListMultipartUploadParts
                 Resource:
-                  - !GetAtt ProwlerFindingsBucket.Arn
-                  - !Sub ${ProwlerFindingsBucket.Arn}/*
+                  - !If
+                    - UseExistingBucket
+                    - !Sub 'arn:${AWS::Partition}:s3:::${ExistingBucketName}'
+                    - !GetAtt ProwlerFindingsBucket.Arn
+                  - !If
+                    - UseExistingBucket
+                    - !Sub 'arn:${AWS::Partition}:s3:::${ExistingBucketName}/*'
+                    - !Sub '${ProwlerFindingsBucket.Arn}/*'
 
   ProwlerReportingCodeBuild:
     Condition: EnableReporting
@@ -1225,7 +1267,7 @@ Resources:
             Value: ''
             Type: PLAINTEXT
           - Name: BUCKET_REPORT
-            Value: !Ref ProwlerFindingsBucket
+            Value: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref ProwlerFindingsBucket]
             Type: PLAINTEXT
       Description: Create Prowler report
       ServiceRole: !GetAtt ProwlerReportingCodeBuildRole.Arn

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ aws cloudformation deploy --template-file 2-sat2-codebuild-prowler.yaml \
 
 When deploying via the Console, enter your bucket name in the **ExistingBucketName** parameter field. Leave it empty to create a new bucket (default behavior).
 
->Note: The existing bucket must have versioning enabled and appropriate permissions for the CodeBuild role to write objects.
+>Note: The existing bucket must have appropriate permissions for the CodeBuild role to write objects.
 
 ## Frequently Asked Questions (FAQ)
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ We have developed an inexpensive, easy to deploy, secure, and fast solution to p
   - [Full scan](#full-scan)
 - [Notifications](#notifications)
 - [Reporting Summary](#reporting-summary)
+- [Using an existing bucket](#using-an-existing-bucket)
 - [Frequently Asked Questions (FAQ)](#frequently-asked-questions-faq)
 - [Clean Up](#clean-up)
 - [Security](#security)
@@ -57,6 +58,7 @@ SATv2 can be customized by updating the CloudFormation parameters. This section 
 | MultiAccountScan         | Set this to true if you want to scan all accounts in your organization. You must have deployed the prerequisite template to provision a role, or specify a different ProwlerRole with the appropriate permissions.                                                                                                                        | [Multi-account scan](#multi-account-scan) |
 | Reporting                | Set this to true if you want to summarize the Prowler reports into a single csv. This is helpful when scanning multiple accounts.                                                                                                                                                                                                         | [Reporting Summary](#reporting-summary)   |
 | EmailAddress             | Specify an address if you want to receive an email when the assessment completes.                                                                                                                                                                                                                                                         | [Notifications](#notifications)           |
+| ExistingBucketName       | Name of an existing S3 bucket to store scan results. Leave empty to create a new bucket. Useful for environments with SCPs that restrict bucket creation.                                                                                                                                                                                 | [Using an existing bucket](#using-an-existing-bucket) |
 | **Advanced Parameters**  |
 | ConcurrentAccountScans   | For multi-account scans, specify the number of accounts to scan concurrently. This is useful for large organizations with many accounts. Selecting more than three changes the size of the CodeBuild instance and may incur additional costs.                                                                                             |
 | CodeBuildTimeout         | Set the timeout for the CodeBuild job. The default is 300 minutes (5 hours).                                                                                                                                                                                                                                                              |
@@ -518,6 +520,31 @@ A saved query is created as an example. This query counts the checks that failed
 5. Choose **Run** to run the query.
 
     ![Athena saved query results](/img/athena-query-results.png)
+
+## Using an existing bucket
+
+By default, the solution creates a new S3 bucket to store Prowler scan results. If you need to use a pre-existing bucket (for example, if your environment has SCPs that restrict S3 bucket creation), you can specify the bucket name using the `ExistingBucketName` parameter.
+
+When `ExistingBucketName` is provided:
+- No new S3 bucket is created
+- All scan results are uploaded to the specified bucket
+- Glue, Athena, and reporting resources use the specified bucket
+- The existing bucket must allow `s3:PutObject` from the CodeBuild role
+
+### AWS CloudShell
+
+```bash
+aws cloudformation deploy --template-file 2-sat2-codebuild-prowler.yaml \
+--stack-name sat2-prowler \
+--capabilities CAPABILITY_NAMED_IAM \
+--parameter-overrides ExistingBucketName=my-existing-bucket-name
+```
+
+### AWS Console
+
+When deploying via the Console, enter your bucket name in the **ExistingBucketName** parameter field. Leave it empty to create a new bucket (default behavior).
+
+>Note: The existing bucket must have versioning enabled and appropriate permissions for the CodeBuild role to write objects.
 
 ## Frequently Asked Questions (FAQ)
 


### PR DESCRIPTION
## Summary

- Add optional `ExistingBucketName` parameter to allow users to provide a pre-existing S3 bucket for storing Prowler scan results instead of creating a new one
- When provided, `ProwlerFindingsBucket` and its bucket policy are skipped — no new bucket is created
- All IAM policies, CodeBuild environment variables, Glue/Athena resources, and EventBridge rules resolve to the correct bucket conditionally
- Supports environments with SCPs that restrict S3 bucket creation

## Test plan

- [x] Deployed with `ExistingBucketName` left empty — new bucket created, scan completed successfully (existing behavior preserved)
- [x] Deployed with `ExistingBucketName` set to a pre-existing bucket — no new bucket created, Prowler scan completed successfully, results uploaded to specified bucket
- [x] Tested in customer environment with SCP restricting bucket creation — deployment and scan succeeded